### PR TITLE
Remove convenience inventory groups (head_nodes, compute_nodes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,8 +161,8 @@ lifecycle on the inventory (bare metal or test VMs). It defaults to `install`.
 
 **Scale-down assumptions:** nodes are already drained and have no running jobs.
 `scale --remove` does not edit inventory automatically; remove hosts from
-`slurmexechosts` (and `compute_nodes`) in `build/hosts.yml` or your static
-inventory, then run `scale` again to regenerate `slurm.conf` on the cluster.
+`slurmexechosts` in `build/hosts.yml` or your static inventory, then run
+`scale` again to regenerate `slurm.conf` on the cluster.
 
 Uninstall removes only Slurm software. It does not destroy DigitalOcean droplets
 (use `./scripts/destroy.sh`) or unmount the shared NFS share.

--- a/ansible/inventory/inventory.example.yml
+++ b/ansible/inventory/inventory.example.yml
@@ -13,7 +13,7 @@
 #       private_ip: 10.200.0.2
 #
 #   children:
-#     # === SLURM Groups ===
+#     # Role groups consumed by galaxyproject.slurm (controller / exec / dbd).
 #     slurmservers:
 #       hosts:
 #         slurm-dev-head:
@@ -25,15 +25,6 @@
 #     slurmdbdservers:
 #       hosts:
 #         slurm-dev-head:
-#
-#     # === Convenience Groups ===
-#     head_nodes:
-#       hosts:
-#         slurm-dev-head:
-#
-#     compute_nodes:
-#       hosts:
-#         slurm-dev-compute-01:
 #
 #   vars:
 #     ansible_user: root

--- a/scripts/configure.sh
+++ b/scripts/configure.sh
@@ -83,7 +83,7 @@ run_scale() {
     echo "Purging Slurm on: ${limit}"
     ansible-playbook playbooks/uninstall.yml --limit "${limit}" -e purge_db=false
     echo ""
-    echo "Remove these hosts from slurmexechosts (and compute_nodes) in your inventory:"
+    echo "Remove these hosts from slurmexechosts in your inventory:"
     echo "  ${REMOVE_HOSTS//,/, }"
     echo ""
     echo "After updating inventory, reconcile the cluster:"

--- a/tofu/hosts.tftpl
+++ b/tofu/hosts.tftpl
@@ -13,7 +13,7 @@ all:
 %{ endfor ~}
 
   children:
-    # === SLURM Groups ===
+    # Role groups consumed by galaxyproject.slurm (controller / exec / dbd).
     slurmservers:
       hosts:
         ${head_node_name}:
@@ -27,17 +27,6 @@ all:
     slurmdbdservers:
       hosts:
         ${head_node_name}:
-
-    # === Convenience Groups ===
-    head_nodes:
-      hosts:
-        ${head_node_name}:
-
-    compute_nodes:
-      hosts:
-%{ for node in compute_nodes ~}
-        ${node.name}:
-%{ endfor ~}
 
   vars:
     ansible_user: root


### PR DESCRIPTION
## Summary
- Remove unused convenience Ansible groups (`head_nodes`, `compute_nodes`) from the Terraform inventory template and example inventory.
- Update scale-down instructions in `configure.sh` and the README to reference only `slurmexechosts`, which is the group actually used by galaxyproject.slurm.

## Test plan
- [x] Run `./scripts/provision.sh` and confirm `build/hosts.yml` is generated without `head_nodes` or `compute_nodes` groups.
- [x] Verify `slurmservers`, `slurmexechosts`, and `slurmdbd` groups are still present and correctly populated.
- [x] Run `./scripts/configure.sh install` against a test cluster and confirm Slurm deploys successfully.
- [ ] Run `./scripts/configure.sh scale --remove <host>` and confirm the updated inventory guidance is accurate.


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Inventory and documentation-only cleanup; playbooks already target Slurm role groups, not the removed convenience groups.
> 
> **Overview**
> Removes the unused Ansible convenience groups **`head_nodes`** and **`compute_nodes`** from the OpenTofu inventory template (`tofu/hosts.tftpl`) and the example inventory. Generated `build/hosts.yml` now only defines the **galaxyproject.slurm** role groups (`slurmservers`, `slurmexechosts`, `slurmdbdservers`).
> 
> Scale-down guidance in the **README** and **`configure.sh`** is aligned so operators edit **`slurmexechosts`** only, not the removed groups.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40731b383146fbfd8faef52e3e02c4a252c5431d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->