### PR TITLE
Document galaxyproject.slurm SlurmctldPidFile workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,3 +113,4 @@ pytest -v tests/test_slurm.py
 
 - [docs/networking.md](docs/networking.md) — why the VPC is referenced, not managed
 - [docs/operations.md](docs/operations.md) — configure/scale, uninstall, and running playbooks directly
+- [docs/ansible-slurm.md](docs/ansible-slurm.md) — `galaxyproject.slurm` role and known upstream issues

--- a/docs/ansible-slurm.md
+++ b/docs/ansible-slurm.md
@@ -1,0 +1,48 @@
+# galaxyproject.slurm role
+
+Slurm is deployed with the upstream
+[galaxyproject/ansible-slurm](https://github.com/galaxyproject/ansible-slurm)
+role, pinned in [`ansible/requirements.yml`](../ansible/requirements.yml).
+Playbooks pass cluster-specific settings through `slurm_config` and
+`slurmdbd_config` in [`ansible/inventory/group_vars/`](../ansible/inventory/group_vars/).
+
+## Known issue: `SlurmctldPidFile` in `slurmdbd.conf`
+
+**Upstream:** [galaxyproject/ansible-slurm#48](https://github.com/galaxyproject/ansible-slurm/issues/48)
+
+The role's default `__slurmdbd_config_default` injects `SlurmctldPidFile` into
+`/etc/slurm/slurmdbd.conf`. That parameter belongs in `slurm.conf` (for
+`slurmctld`); it is not recognized by `slurmdbd`. The valid slurmdbd setting is
+[`PidFile`](https://slurm.schedmd.com/slurmdbd.conf.html#OPT_PidFile).
+
+Without a workaround, `slurmdbd` fails to start:
+
+```
+error: _parse_next_key: Parsing error at unrecognized key: SlurmctldPidFile
+fatal: Could not open/read/parse slurmdbd.conf file /etc/slurm/slurmdbd.conf
+```
+
+### Workaround
+
+In `slurmdbd_config` for slurmdbd hosts:
+
+1. Set `PidFile` to the desired slurmdbd PID path.
+2. Set `SlurmctldPidFile: "{{ omit }}"` so Ansible drops the incorrect default
+   instead of writing it into `slurmdbd.conf`.
+
+This repository applies the fix in
+[`ansible/inventory/group_vars/slurmdbdservers.yml`](../ansible/inventory/group_vars/slurmdbdservers.yml):
+
+```yaml
+slurmdbd_config:
+  # ...
+  PidFile: /run/slurmdbd.pid
+  SlurmctldPidFile: "{{ omit }}"  # overrides the incorrect role default
+```
+
+Other workarounds discussed on the upstream issue include overriding
+`__slurmdbd_config_default` entirely; the `omit` override above is the smallest
+change and matches what we use here.
+
+Remove the `SlurmctldPidFile` line once upstream merges a fix and the pinned
+role version includes it.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -44,3 +44,8 @@ ansible-playbook playbooks/slurmdbd.yml
 ansible-playbook playbooks/slurm.yml
 ansible-playbook playbooks/uninstall.yml   # full purge; use -e purge_db=false for partial
 ```
+
+Slurmdbd host variables live in
+[`inventory/group_vars/slurmdbdservers.yml`](../ansible/inventory/group_vars/slurmdbdservers.yml).
+If `slurmdbd` fails to parse its config, see
+[ansible-slurm.md](ansible-slurm.md#known-issue-slurmctldpidfile-in-slurmdbdconf).


### PR DESCRIPTION
## Summary
- Add `docs/ansible-slurm.md` documenting the upstream `galaxyproject/ansible-slurm` issue where `SlurmctldPidFile` is incorrectly written to `slurmdbd.conf`
- Link the workaround (`PidFile` + `SlurmctldPidFile: "{{ omit }}"`) to the existing config in `slurmdbdservers.yml`
- Cross-link from README and `docs/operations.md`

## Test plan
- [x] Verify links in README and operations doc resolve correctly
- [ ] Confirm the upstream issue link and workaround match `ansible/inventory/group_vars/slurmdbdservers.yml`


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, Ansible, or infrastructure behavior changes.
> 
> **Overview**
> Adds **`docs/ansible-slurm.md`** to document the upstream **`galaxyproject/ansible-slurm`** bug that writes **`SlurmctldPidFile`** into **`slurmdbd.conf`**, the resulting **`slurmdbd`** parse failure, and the repo workaround (**`PidFile`** plus **`SlurmctldPidFile: "{{ omit }}"`** in **`slurmdbd_config`**, as in **`slurmdbdservers.yml`**).
> 
> **README** and **`docs/operations.md`** now link to that doc and point operators at **`slurmdbdservers.yml`** when **`slurmdbd`** won’t start.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 955a224f6360707f71719e30e7a8615c1a6957ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->