### PR TITLE
Fix /etc/hosts cleanup under --limit in scale --remove

### DIFF
--- a/ansible/playbooks/clean_hosts.yml
+++ b/ansible/playbooks/clean_hosts.yml
@@ -1,0 +1,23 @@
+---
+# Remove /etc/hosts entries for decommissioned compute nodes across the whole
+# cluster. During scale-down, `uninstall.yml --limit <removed>` only edits the
+# nodes being discarded, leaving stale entries on the controller and remaining
+# nodes. This play runs on every host (gather_facts disabled) and deletes the
+# matching lines by IP, so no gathered facts are required.
+#
+# Pass the hosts to clean via `-e remove_hosts=h1,h2`. They must still be in the
+# inventory when this runs so their private_ip can be resolved.
+- name: Remove decommissioned nodes from /etc/hosts
+  hosts: all
+  become: true
+  gather_facts: false
+  vars:
+    remove_hosts: ""
+  tasks:
+    - name: Remove /etc/hosts entries for removed nodes
+      ansible.builtin.lineinfile:
+        path: /etc/hosts
+        regexp: "^{{ hostvars[item].private_ip | default(item) | regex_escape }}\\s"
+        state: absent
+      loop: "{{ remove_hosts.split(',') | map('trim') | select | list }}"
+      failed_when: false

--- a/ansible/playbooks/uninstall.yml
+++ b/ansible/playbooks/uninstall.yml
@@ -134,10 +134,14 @@
         state: absent
       failed_when: false
 
+    # Match the entry by IP (regexp) rather than rebuilding the full line.
+    # The line includes ansible_hostname, a gathered fact that is undefined for
+    # hosts outside a --limit run (e.g. scale --remove), which would raise
+    # AnsibleUndefinedVariable. private_ip resolves from inventory data alone.
     - name: Remove SLURM controller from /etc/hosts
       ansible.builtin.lineinfile:
         path: /etc/hosts
-        line: "{{ hostvars[groups['slurmservers'][0]].private_ip }} {{ hostvars[groups['slurmservers'][0]].ansible_hostname }}"
+        regexp: "^{{ hostvars[groups['slurmservers'][0]].private_ip | regex_escape }}\\s"
         state: absent
       when: groups['slurmservers'] | length > 0
       failed_when: false
@@ -145,7 +149,7 @@
     - name: Remove compute nodes from /etc/hosts
       ansible.builtin.lineinfile:
         path: /etc/hosts
-        line: "{{ hostvars[item].private_ip }} {{ hostvars[item].ansible_hostname }}"
+        regexp: "^{{ hostvars[item].private_ip | regex_escape }}\\s"
         state: absent
       loop: "{{ groups['slurmexechosts'] }}"
       failed_when: false

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -21,10 +21,50 @@ lifecycle on the inventory (bare metal or test VMs). It defaults to `install`.
 ./scripts/configure.sh scale
 ```
 
-**Scale-down assumptions:** nodes are already drained and have no running jobs.
-`scale --remove` does not edit inventory automatically; remove hosts from
-`slurmexechosts` in `build/hosts.ini` or your static inventory, then run
-`scale` again to regenerate `slurm.conf` on the cluster.
+### Removing a node from the cluster
+
+Follow this end-to-end procedure to decommission one or more compute nodes
+cleanly. It avoids stale state on the controller and the nodes that remain.
+
+1. **Drain the node(s) and confirm no running jobs.** On the controller:
+
+   ```bash
+   scontrol update NodeName=slurm-dev-compute-02 State=DRAIN Reason="decommission"
+   squeue -w slurm-dev-compute-02      # wait until empty
+   ```
+
+2. **Purge Slurm on the removed node(s) and clean `/etc/hosts` cluster-wide.**
+   The hosts must still be present in the inventory at this point so their IPs
+   resolve:
+
+   ```bash
+   ./scripts/configure.sh scale --remove slurm-dev-compute-02
+   ```
+
+   This purges Slurm on the listed hosts (`uninstall.yml --limit`, keeping the
+   accounting DB) and then runs `clean_hosts.yml` across every host to remove
+   the decommissioned nodes' `/etc/hosts` entries from the controller and the
+   remaining nodes — not just the discarded ones.
+
+3. **Remove the host(s) from `slurmexechosts`** in `build/hosts.ini` (or your
+   static inventory). `scale --remove` does not edit the inventory for you.
+
+4. **Reconcile the remaining cluster.** Regenerates `slurm.conf` for the new
+   topology and reconfigures the controller:
+
+   ```bash
+   ./scripts/configure.sh scale
+   ```
+
+5. **Verify the new topology** from the controller:
+
+   ```bash
+   sinfo
+   scontrol show nodes
+   ```
+
+   The removed node(s) should no longer appear, and the remaining nodes should
+   report a healthy state (`idle`/`mixed`/`allocated`).
 
 Uninstall removes only Slurm software. It does not destroy DigitalOcean droplets
 (use `./scripts/destroy.sh`) or unmount the shared NFS share.

--- a/scripts/configure.sh
+++ b/scripts/configure.sh
@@ -12,8 +12,10 @@ Usage: configure.sh [install|uninstall|scale] [options]
   uninstall            Full purge of Slurm, munge, and MariaDB on all nodes.
   scale [--remove h1,h2]
                        Reconcile cluster to current inventory (scale up).
-                       With --remove: purge Slurm on listed hosts only, then
-                       print steps to remove them from inventory and re-run scale.
+                       With --remove: drain the listed hosts first, then this
+                       purges Slurm on them, cleans their /etc/hosts entries
+                       cluster-wide, and prints steps to remove them from
+                       inventory and re-run scale.
 
 Options:
   --remove HOSTS       Comma-separated hostnames to remove (scale only).
@@ -82,6 +84,12 @@ run_scale() {
     local limit="${REMOVE_HOSTS//,/,}"
     echo "Purging Slurm on: ${limit}"
     ansible-playbook playbooks/uninstall.yml --limit "${limit}" -e purge_db=false
+    # Clean stale /etc/hosts entries for the removed nodes everywhere, while they
+    # are still in the inventory. The --limit purge above only edits the removed
+    # nodes themselves, leaving stale entries on the controller and the nodes
+    # that remain in the cluster.
+    echo "Cleaning /etc/hosts entries for removed nodes across the cluster"
+    ansible-playbook playbooks/clean_hosts.yml -e "remove_hosts=${REMOVE_HOSTS}"
     echo ""
     echo "Remove these hosts from slurmexechosts in your inventory:"
     echo "  ${REMOVE_HOSTS//,/, }"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #15. In the `configure.sh scale --remove h1,h2` path, the `/etc/hosts` cleanup tasks in `uninstall.yml` built each line from the gathered fact `ansible_hostname`, which is only defined for hosts inside a `--limit` run. Dereferencing it for any host outside the limit raised `AnsibleUndefinedVariable` (and `failed_when: false` does not reliably catch templating errors). Separately, under `--limit` the cleanup only edited the nodes being discarded, leaving stale entries on the controller and the remaining nodes.

## Changes

- **`ansible/playbooks/uninstall.yml`**: the two `/etc/hosts` removal tasks now match by IP via `regexp` (`regex_escape` on `private_ip`) instead of rebuilding the full `line:`. `private_ip` (`{{ ansible_host | default(inventory_hostname) }}`) resolves from inventory data alone, so no gathered facts are needed and there is no `--limit`-dependent variable to be undefined.
- **`ansible/playbooks/clean_hosts.yml`** (new): removes decommissioned nodes' `/etc/hosts` entries across the whole cluster (controller + remaining nodes), not just the discarded ones. Runs with `gather_facts: false` and matches by IP. Takes `-e remove_hosts=h1,h2`.
- **`scripts/configure.sh`**: `scale --remove` now runs `clean_hosts.yml` after the per-node purge (while the removed hosts are still in inventory so their IPs resolve), and the help text clarifies the drain-first flow.
- **`docs/operations.md`**: documents the end-to-end node-removal procedure (drain, `scale --remove`, edit inventory, `scale`, verify with `sinfo` / `scontrol show nodes`).

## Validation

- `ansible-playbook --syntax-check` passes for both `uninstall.yml` and `clean_hosts.yml`.
- `bash -n scripts/configure.sh` passes.
- Functional check: ran the removal task against a raw-IP inventory with `gather_facts: false` and `--limit` set to the controller only (so the removed hosts are outside the play). `hostvars[item].private_ip` still resolved from inventory and both stale lines were removed with no undefined-variable error.
- Live multi-node cluster apply was not available in this environment.

## Acceptance criteria

- [x] `configure.sh scale --remove` runs without undefined-variable errors.
- [x] `/etc/hosts` entries for removed nodes are cleaned on the remaining nodes (not just the removed node).
- [x] Documented node-removal procedure in `docs/operations.md`.

## Follow-up (out of scope)

Full end-to-end automated testing of scale up/down requires a live multi-node cluster (DigitalOcean droplets via `tofu` or a container/molecule harness) and is best tracked as a separate issue/PR. Automated inventory editing also remains manual, unchanged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-525594e1-5b94-405c-b9be-af425230c304"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-525594e1-5b94-405c-b9be-af425230c304"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

